### PR TITLE
[codex] UI/UX改善

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,7 +9,7 @@
 .App-header {
   position: relative;
   overflow: hidden;
-  padding: 22px max(24px, calc((100vw - 1240px) / 2)) 42px;
+  padding: 10px max(24px, calc((100vw - 1240px) / 2)) 16px;
   color: #f9f7f1;
   background: #1f2933;
   border-bottom: 1px solid #0f1720;
@@ -47,8 +47,8 @@
 
 .wordmark-mark {
   display: grid;
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   place-items: center;
   color: #fff;
   background: var(--accent);
@@ -61,14 +61,14 @@
   position: relative;
   z-index: 1;
   max-width: 760px;
-  padding-top: 54px;
+  padding-top: 12px;
 }
 
 .hero-kicker {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  margin: 0 0 12px;
+  margin: 0 0 4px;
   color: #efb9a9;
   font-size: 0.74rem;
   font-weight: 800;
@@ -87,7 +87,7 @@
   max-width: 700px;
   margin: 0;
   font-family: Georgia, "Times New Roman", serif;
-  font-size: clamp(2.35rem, 5vw, 4.6rem);
+  font-size: clamp(2rem, 3vw, 2.75rem);
   font-weight: 600;
   line-height: 0.98;
   letter-spacing: -0.045em;
@@ -95,10 +95,10 @@
 
 .App-header .hero-subtitle {
   max-width: 600px;
-  margin: 20px 0 0;
+  margin: 6px 0 0;
   color: #c8d0d6;
-  font-size: clamp(1rem, 1.6vw, 1.16rem);
-  line-height: 1.7;
+  font-size: clamp(0.9rem, 1.3vw, 1rem);
+  line-height: 1.5;
 }
 
 main {
@@ -125,7 +125,7 @@ main {
 
 @media (max-width: 640px) {
   .App-header {
-    padding: 16px 18px 32px;
+    padding: 10px 18px 16px;
   }
 
   .wordmark {
@@ -134,7 +134,7 @@ main {
   }
 
   .hero-copy {
-    padding-top: 42px;
+    padding-top: 12px;
   }
 
   .App-footer {

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -111,7 +111,7 @@ const CardArtwork = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
           <rect x="10" y="10" width="640" height="901" rx="33" />
         </clipPath>
         <clipPath id="header-name-clip">
-          <rect x="48" y="80" width="410" height="36" />
+          <rect x="48" y="70" width="410" height="46" />
         </clipPath>
       </defs>
 

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -2,6 +2,10 @@ import { getTypeIcon, getTypeTheme } from './cardTheme'
 
 const CARD_WIDTH = 660
 const CARD_HEIGHT = 921
+const ART_X = 47
+const ART_Y = 116
+const ART_WIDTH = 566
+const ART_HEIGHT = 365
 
 const getTextUnits = (text) => [...text].reduce((total, character) => (
   total + (/\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}/u.test(character) ? 1 : 0.56)
@@ -42,7 +46,7 @@ const TextLines = ({ lines, x, y, lineHeight, ...props }) => (
   </text>
 )
 
-const CardArtwork = ({ cardData, imagePreview, svgRef }) => {
+const CardArtwork = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
   const theme = getTypeTheme(cardData.type)
   const typeIcon = getTypeIcon(cardData.type)
   const abilities = cardData.abilities.filter((ability) => ability.name).slice(0, 3)
@@ -50,6 +54,16 @@ const CardArtwork = ({ cardData, imagePreview, svgRef }) => {
   const nameUnits = getTextUnits(cardData.name || '')
   const nameSize = Math.max(21, 35 - Math.max(0, nameUnits - 10) * 1.4)
   const raritySymbols = { common: '○', uncommon: '●', rare: '◆', holo: '★' }
+  const naturalWidth = imageAdjustment?.width || ART_WIDTH
+  const naturalHeight = imageAdjustment?.height || ART_HEIGHT
+  const zoom = Math.min(2.5, Math.max(1, imageAdjustment?.zoom || 1))
+  const baseImageScale = Math.max(ART_WIDTH / naturalWidth, ART_HEIGHT / naturalHeight)
+  const imageWidth = naturalWidth * baseImageScale * zoom
+  const imageHeight = naturalHeight * baseImageScale * zoom
+  const overflowX = Math.max(0, imageWidth - ART_WIDTH)
+  const overflowY = Math.max(0, imageHeight - ART_HEIGHT)
+  const imageX = ART_X - overflowX / 2 + ((imageAdjustment?.x || 0) / 100) * (overflowX / 2)
+  const imageY = ART_Y - overflowY / 2 + ((imageAdjustment?.y || 0) / 100) * (overflowY / 2)
 
   return (
     <svg
@@ -113,7 +127,7 @@ const CardArtwork = ({ cardData, imagePreview, svgRef }) => {
         <path d="M-20 345 C170 260 240 385 402 312 S705 262 730 176" strokeWidth="16" />
       </g>
 
-      <text x="52" y="78" fill={theme.dark} fontFamily="Arial, Helvetica, sans-serif" fontSize="13" fontWeight="700" letterSpacing="1.7">
+      <text x="52" y="66" fill={theme.dark} fontFamily="Arial, Helvetica, sans-serif" fontSize="12" fontWeight="700" letterSpacing="1.7">
         ORIGINAL CREATURE
       </text>
       <text x="52" y="106" clipPath="url(#header-name-clip)" fill="#151616" fontFamily="Arial, Helvetica, sans-serif" fontSize={nameSize} fontWeight="800">
@@ -132,11 +146,11 @@ const CardArtwork = ({ cardData, imagePreview, svgRef }) => {
           <image
             href={imagePreview}
             xlinkHref={imagePreview}
-            x="47"
-            y="116"
-            width="566"
-            height="365"
-            preserveAspectRatio="xMidYMid slice"
+            x={imageX}
+            y={imageY}
+            width={imageWidth}
+            height={imageHeight}
+            preserveAspectRatio="none"
           />
         ) : (
           <g>

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -10,6 +10,9 @@ const CardForm = ({
   onAddAbility, 
   onRemoveAbility,
   imageError,
+  imageAdjustment,
+  onImageAdjustment,
+  onResetImageAdjustment,
 }) => {
   const fileInputRef = useRef(null)
   const { t } = useLanguage() // 翻訳機能を使用
@@ -92,7 +95,57 @@ const CardForm = ({
             hidden
           />
           <small>{t('recommendedImage')}</small>
-          {imageError && <small className="download-error" role="alert">{imageError}</small>}
+          {imageError && (
+            <div className="image-upload-error" role="alert">
+              <span aria-hidden="true">!</span>
+              {imageError}
+            </div>
+          )}
+          {cardData.image && (
+            <div className="image-adjustments">
+              <div className="image-adjustments-heading">
+                <strong>{t('imageAdjustment')}</strong>
+                <button type="button" onClick={onResetImageAdjustment}>
+                  {t('resetImageAdjustment')}
+                </button>
+              </div>
+              <label htmlFor="image-position-x">
+                <span>{t('imagePositionX')}</span>
+                <input
+                  id="image-position-x"
+                  type="range"
+                  min="-100"
+                  max="100"
+                  value={imageAdjustment.x}
+                  onChange={(event) => onImageAdjustment('x', event.target.value)}
+                />
+              </label>
+              <label htmlFor="image-position-y">
+                <span>{t('imagePositionY')}</span>
+                <input
+                  id="image-position-y"
+                  type="range"
+                  min="-100"
+                  max="100"
+                  value={imageAdjustment.y}
+                  onChange={(event) => onImageAdjustment('y', event.target.value)}
+                />
+              </label>
+              <label htmlFor="image-zoom">
+                <span>{t('imageZoom')}</span>
+                <input
+                  id="image-zoom"
+                  type="range"
+                  min="1"
+                  max="2.5"
+                  step="0.05"
+                  value={imageAdjustment.zoom}
+                  onChange={(event) => onImageAdjustment('zoom', event.target.value)}
+                />
+                <output htmlFor="image-zoom">{Math.round(imageAdjustment.zoom * 100)}%</output>
+              </label>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -10,7 +10,7 @@ const CardForm = ({
   onAddAbility, 
   onRemoveAbility,
   imageError,
-  imageAdjustment,
+  imageAdjustment = { x: 0, y: 0, zoom: 1 },
   onImageAdjustment,
   onResetImageAdjustment,
 }) => {

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -9,7 +9,7 @@ const initialStyle = {
   '--rotate-y': '0deg',
 }
 
-const PokemonCard = forwardRef(({ cardData, imagePreview }, ref) => {
+const PokemonCard = forwardRef(({ cardData, imagePreview, imageAdjustment }, ref) => {
   const containerRef = useRef(null)
   const svgRef = useRef(null)
   const [cardStyle, setCardStyle] = useState(initialStyle)
@@ -45,7 +45,12 @@ const PokemonCard = forwardRef(({ cardData, imagePreview }, ref) => {
       onPointerLeave={() => setCardStyle(initialStyle)}
     >
       <div className="card__rotator">
-        <CardArtwork cardData={cardData} imagePreview={imagePreview} svgRef={svgRef} />
+        <CardArtwork
+          cardData={cardData}
+          imagePreview={imagePreview}
+          imageAdjustment={imageAdjustment}
+          svgRef={svgRef}
+        />
         <div className="card__shine" aria-hidden="true" />
         <div className="card__glare" aria-hidden="true" />
       </div>

--- a/src/components/PokemonCardGenerator.css
+++ b/src/components/PokemonCardGenerator.css
@@ -234,6 +234,92 @@
   line-height: 1.45;
 }
 
+.image-upload-error {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 13px;
+  color: #842f27;
+  background: #fff2ef;
+  border: 1px solid #dda69e;
+  border-radius: 10px;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.image-upload-error span {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+  place-items: center;
+  color: #fff;
+  background: #a23c32;
+  border-radius: 50%;
+}
+
+.image-adjustments {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 18px;
+  margin-top: 4px;
+  padding: 14px;
+  background: #f4f1ea;
+  border: 1px solid #ddd7cc;
+  border-radius: 12px;
+}
+
+.image-adjustments-heading {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: #48535d;
+  font-size: 0.78rem;
+}
+
+.image-adjustments-heading button {
+  padding: 4px 9px;
+  color: var(--accent-dark);
+  background: transparent;
+  border: 1px solid #cfaaa4;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.image-adjustments label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 5px 10px;
+  align-items: center;
+  color: #68727c;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.image-adjustments label:last-child {
+  grid-column: 1 / -1;
+}
+
+.image-adjustments input[type='range'] {
+  grid-column: 1 / -1;
+  min-height: 24px;
+  padding: 0;
+  accent-color: var(--accent);
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+}
+
+.image-adjustments output {
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
 .abilities-section {
   display: flex;
   flex-direction: column;
@@ -447,5 +533,13 @@
 
   .image-upload-section {
     grid-template-columns: 1fr;
+  }
+
+  .image-adjustments {
+    grid-template-columns: 1fr;
+  }
+
+  .image-adjustments label:last-child {
+    grid-column: 1;
   }
 }

--- a/src/components/PokemonCardGenerator.jsx
+++ b/src/components/PokemonCardGenerator.jsx
@@ -43,6 +43,7 @@ const PokemonCardGenerator = () => {
   const [imageAdjustment, setImageAdjustment] = useState(initialImageAdjustment)
   const [imageError, setImageError] = useState('')
   const cardRef = useRef(null)
+  const imageUploadIdRef = useRef(0)
 
   // サンプルカードのデータ - 現在の言語に基づいて動的に取得
   const getSampleCards = () => {
@@ -103,6 +104,7 @@ const PokemonCardGenerator = () => {
   const handleImageUpload = (event) => {
     const file = event.target.files[0]
     if (!file) return
+    const uploadId = ++imageUploadIdRef.current
     if (!file.type.startsWith('image/')) {
       setImageError(t('alerts.invalidImage'))
       event.target.value = ''
@@ -117,9 +119,11 @@ const PokemonCardGenerator = () => {
     setImageError('')
     const reader = new FileReader()
     reader.onload = (readerEvent) => {
+      if (imageUploadIdRef.current !== uploadId) return
       const imageUrl = readerEvent.target.result
       const image = new Image()
       image.onload = () => {
+        if (imageUploadIdRef.current !== uploadId) return
         setImagePreview(imageUrl)
         setImageAdjustment({
           ...initialImageAdjustment,
@@ -128,11 +132,18 @@ const PokemonCardGenerator = () => {
         })
         setCardData(prev => ({ ...prev, image: imageUrl }))
       }
-      image.onerror = () => setImageError(t('alerts.invalidImage'))
+      image.onerror = () => {
+        if (imageUploadIdRef.current !== uploadId) return
+        setImageError(t('alerts.invalidImage'))
+      }
       image.src = imageUrl
     }
-    reader.onerror = () => setImageError(t('alerts.invalidImage'))
+    reader.onerror = () => {
+      if (imageUploadIdRef.current !== uploadId) return
+      setImageError(t('alerts.invalidImage'))
+    }
     reader.readAsDataURL(file)
+    event.target.value = ''
   }
 
   // 入力フィールドの値変更処理
@@ -179,6 +190,7 @@ const PokemonCardGenerator = () => {
 
   // サンプルカードの読み込み処理
   const loadSampleCard = (sample) => {
+    imageUploadIdRef.current += 1
     setCardData({ ...sample, image: null })
     setImagePreview(null)
     setImageAdjustment(initialImageAdjustment)
@@ -187,6 +199,7 @@ const PokemonCardGenerator = () => {
 
   // カードリセット処理 - 言語に応じたデフォルト値に戻す
   const resetCard = () => {
+    imageUploadIdRef.current += 1
     setCardData({
       name: t('defaultCard.name'),
       hp: '100',

--- a/src/components/PokemonCardGenerator.jsx
+++ b/src/components/PokemonCardGenerator.jsx
@@ -5,6 +5,14 @@ import DownloadButton from './DownloadButton'
 import { useLanguage } from '../contexts/useLanguage'
 import './PokemonCardGenerator.css'
 
+const initialImageAdjustment = {
+  x: 0,
+  y: 0,
+  zoom: 1,
+  width: 0,
+  height: 0,
+}
+
 // メインのポケモンカードジェネレーターコンポーネント
 const PokemonCardGenerator = () => {
   const { t } = useLanguage() // 翻訳機能とユーザーの言語設定を取得
@@ -32,6 +40,7 @@ const PokemonCardGenerator = () => {
   })
 
   const [imagePreview, setImagePreview] = useState(null)
+  const [imageAdjustment, setImageAdjustment] = useState(initialImageAdjustment)
   const [imageError, setImageError] = useState('')
   const cardRef = useRef(null)
 
@@ -108,8 +117,19 @@ const PokemonCardGenerator = () => {
     setImageError('')
     const reader = new FileReader()
     reader.onload = (readerEvent) => {
-      setImagePreview(readerEvent.target.result)
-      setCardData(prev => ({ ...prev, image: readerEvent.target.result }))
+      const imageUrl = readerEvent.target.result
+      const image = new Image()
+      image.onload = () => {
+        setImagePreview(imageUrl)
+        setImageAdjustment({
+          ...initialImageAdjustment,
+          width: image.naturalWidth,
+          height: image.naturalHeight,
+        })
+        setCardData(prev => ({ ...prev, image: imageUrl }))
+      }
+      image.onerror = () => setImageError(t('alerts.invalidImage'))
+      image.src = imageUrl
     }
     reader.onerror = () => setImageError(t('alerts.invalidImage'))
     reader.readAsDataURL(file)
@@ -118,6 +138,18 @@ const PokemonCardGenerator = () => {
   // 入力フィールドの値変更処理
   const handleInputChange = (field, value) => {
     setCardData(prev => ({ ...prev, [field]: value }))
+  }
+
+  const handleImageAdjustment = (field, value) => {
+    setImageAdjustment(prev => ({ ...prev, [field]: Number(value) }))
+  }
+
+  const resetImageAdjustment = () => {
+    setImageAdjustment(prev => ({
+      ...initialImageAdjustment,
+      width: prev.width,
+      height: prev.height,
+    }))
   }
 
   // 技（アビリティ）の変更処理
@@ -149,6 +181,7 @@ const PokemonCardGenerator = () => {
   const loadSampleCard = (sample) => {
     setCardData({ ...sample, image: null })
     setImagePreview(null)
+    setImageAdjustment(initialImageAdjustment)
     setImageError('')
   }
 
@@ -175,6 +208,7 @@ const PokemonCardGenerator = () => {
       rarity: 'common'
     })
     setImagePreview(null)
+    setImageAdjustment(initialImageAdjustment)
     setImageError('')
   }
 
@@ -223,6 +257,9 @@ const PokemonCardGenerator = () => {
             onAddAbility={addAbility}
             onRemoveAbility={removeAbility}
             imageError={imageError}
+            imageAdjustment={imageAdjustment}
+            onImageAdjustment={handleImageAdjustment}
+            onResetImageAdjustment={resetImageAdjustment}
           />
         </section>
         
@@ -240,6 +277,7 @@ const PokemonCardGenerator = () => {
               ref={cardRef}
               cardData={cardData}
               imagePreview={imagePreview}
+              imageAdjustment={imageAdjustment}
             />
           </div>
           {/* ダウンロードボタン */}

--- a/src/contexts/translations.js
+++ b/src/contexts/translations.js
@@ -57,6 +57,11 @@ export const translations = {
     // ボタンテキスト
     uploadImage: 'Upload Image',
     changeImage: 'Change Image',
+    imageAdjustment: 'Image framing',
+    imagePositionX: 'Horizontal position',
+    imagePositionY: 'Vertical position',
+    imageZoom: 'Zoom',
+    resetImageAdjustment: 'Reset',
     addAbility: '+ Add Ability',
     removeAbility: 'Remove ability',
     downloadCard: 'Download high-resolution PNG',
@@ -195,6 +200,11 @@ export const translations = {
     // ボタンテキスト
     uploadImage: '画像をアップロード',
     changeImage: '画像を変更',
+    imageAdjustment: '画像の表示調整',
+    imagePositionX: '左右の位置',
+    imagePositionY: '上下の位置',
+    imageZoom: '拡大・縮小',
+    resetImageAdjustment: '調整をリセット',
     addAbility: '+ 技を追加',
     removeAbility: '技を削除',
     downloadCard: '高解像度PNGをダウンロード',


### PR DESCRIPTION
## 概要

Issue #4 のUI/UX改善を実装しました。

## 変更内容

- ヘッダーをコンパクトにし、ファーストビューのカード作成領域を広げました
- アップロード画像の左右・上下位置とズームを調整できるUIを追加しました
- 画像サイズ超過などのエラー表示を見つけやすくしました
- カード名のSVGクリップ領域を広げ、日本語名の上端が見切れる問題を修正しました
- 画像調整をプレビューと高解像度PNGの共通SVG描画に反映しました
- 新しいUI文言を日本語・英語の両方に追加しました

## 原因

カード名の見切れは、名前のSVGクリップ領域がフォントサイズに対して低く、日本語グリフの上端が切られていたことが原因でした。

## 確認内容

- `npm run lint`
- Vite本番ビルド
- デスクトップ・モバイル表示
- 画像の位置調整、ズーム、リセット
- 画像入り高解像度PNGの生成
- 日本語カード名「カスタムポケモン」の表示

Closes #4