### PR TITLE
[codex] 逃げるコスト0と4桁HPに対応

### DIFF
--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -184,7 +184,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
       <text x="61" y="116" clipPath="url(#full-art-name-clip)" fill="#111516" fontFamily="Arial, Helvetica, sans-serif" fontSize={nameSize} fontWeight="850">
         {cardData.name || 'Untitled'}
       </text>
-      <text x="466" y="110" fill="#303637" fontFamily="Arial, Helvetica, sans-serif" fontSize="15" fontWeight="800">HP</text>
+      <text x="460" y="110" textAnchor="end" fill="#303637" fontFamily="Arial, Helvetica, sans-serif" fontSize="15" fontWeight="800">HP</text>
       <text x="548" y="116" textAnchor="end" fill="#111516" fontFamily="Arial, Helvetica, sans-serif" fontSize="35" fontWeight="850">
         {cardData.hp || '—'}
       </text>
@@ -367,7 +367,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
       <text x="51" y="100" clipPath="url(#header-name-clip)" fill="#111" fontFamily="Arial, Helvetica, sans-serif" fontSize={nameSize} fontWeight="850" letterSpacing="-0.5">
         {cardData.name || 'Untitled'}
       </text>
-      <text x="472" y="94" fill={theme.dark} fontFamily="Arial, Helvetica, sans-serif" fontSize="13" fontWeight="850">HP</text>
+      <text x="468" y="94" textAnchor="end" fill={theme.dark} fontFamily="Arial, Helvetica, sans-serif" fontSize="13" fontWeight="850">HP</text>
       <text x="558" y="97" textAnchor="end" fill="#111" fontFamily="Arial, Helvetica, sans-serif" fontSize="36" fontWeight="900" letterSpacing="-1">
         {cardData.hp || '—'}
       </text>

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -191,7 +191,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
       </text>
       <text x="548" y="116" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
         <tspan fill="#303637" fontSize="15" fontWeight="800" dy="-6">HP</tspan>
-        <tspan fill="#111516" fontSize="35" fontWeight="850" dy="6">{' '}{cardData.hp || '—'}</tspan>
+        <tspan fill="#111516" fontSize="35" fontWeight="850" dy="6" dx="5">{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="556" y="75" width="48" height="48" />
 
@@ -374,7 +374,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
       </text>
       <text x="558" y="97" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
         <tspan fill={theme.dark} fontSize="13" fontWeight="850" dy="-3">HP</tspan>
-        <tspan fill="#111" fontSize="36" fontWeight="900" letterSpacing="-1" dy="3">{' '}{cardData.hp || '—'}</tspan>
+        <tspan fill="#111" fontSize="36" fontWeight="900" letterSpacing="-1" dy="3" dx="5">{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="566" y="57" width="46" height="46" />
 

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -145,7 +145,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
           <rect x={FULL_ART_X} y={FULL_ART_Y} width={FULL_ART_WIDTH} height={FULL_ART_HEIGHT} rx="26" />
         </clipPath>
         <clipPath id="full-art-name-clip">
-          <rect x="59" y="78" width="405" height="49" />
+          <rect x="59" y="78" width="370" height="49" />
         </clipPath>
       </defs>
 
@@ -184,9 +184,9 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
       <text x="61" y="116" clipPath="url(#full-art-name-clip)" fill="#111516" fontFamily="Arial, Helvetica, sans-serif" fontSize={nameSize} fontWeight="850">
         {cardData.name || 'Untitled'}
       </text>
-      <text x="460" y="110" textAnchor="end" fill="#303637" fontFamily="Arial, Helvetica, sans-serif" fontSize="15" fontWeight="800">HP</text>
-      <text x="548" y="116" textAnchor="end" fill="#111516" fontFamily="Arial, Helvetica, sans-serif" fontSize="35" fontWeight="850">
-        {cardData.hp || '—'}
+      <text x="548" y="116" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
+        <tspan fill="#303637" fontSize="15" fontWeight="800" dy="-6">HP</tspan>
+        <tspan fill="#111516" fontSize="35" fontWeight="850" dy="6">{' '}{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="556" y="75" width="48" height="48" />
 
@@ -228,7 +228,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
         <rect x="45" y="808" width="570" height="75" rx="18" fill="#f5f8f5" fillOpacity="0.86" stroke="#d7dedc" strokeWidth="2" />
       </g>
       <text x="65" y="837" fill="#252b2c" fontFamily="Arial, Helvetica, sans-serif" fontSize="11" fontWeight="800" letterSpacing="0.8">RETREAT</text>
-      {Array.from({ length: Math.min(Number(cardData.retreatCost) || 0, 5) }).map((_, index) => (
+      {Array.from({ length: Math.min(Number(cardData.retreatCost ?? 1), 5) }).map((_, index) => (
         <image key={index} href={getTypeIcon('normal')} xlinkHref={getTypeIcon('normal')} x={124 + index * 21} y="824" width="18" height="18" />
       ))}
       <text x="330" y="837" textAnchor="middle" fill="#303738" fontFamily="Arial, Helvetica, sans-serif" fontSize="11" fontWeight="750" letterSpacing="0.8">FAN-MADE • NOT FOR SALE</text>
@@ -340,7 +340,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
           <rect x="10" y="10" width="640" height="901" rx="33" />
         </clipPath>
         <clipPath id="header-name-clip">
-          <rect x="48" y="70" width="410" height="46" />
+          <rect x="48" y="70" width="380" height="46" />
         </clipPath>
       </defs>
 
@@ -367,9 +367,9 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
       <text x="51" y="100" clipPath="url(#header-name-clip)" fill="#111" fontFamily="Arial, Helvetica, sans-serif" fontSize={nameSize} fontWeight="850" letterSpacing="-0.5">
         {cardData.name || 'Untitled'}
       </text>
-      <text x="468" y="94" textAnchor="end" fill={theme.dark} fontFamily="Arial, Helvetica, sans-serif" fontSize="13" fontWeight="850">HP</text>
-      <text x="558" y="97" textAnchor="end" fill="#111" fontFamily="Arial, Helvetica, sans-serif" fontSize="36" fontWeight="900" letterSpacing="-1">
-        {cardData.hp || '—'}
+      <text x="558" y="97" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
+        <tspan fill={theme.dark} fontSize="13" fontWeight="850" dy="-3">HP</tspan>
+        <tspan fill="#111" fontSize="36" fontWeight="900" letterSpacing="-1" dy="3">{' '}{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="566" y="57" width="46" height="46" />
 
@@ -451,7 +451,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
       {resistanceIcon ? <image href={resistanceIcon} xlinkHref={resistanceIcon} x="280" y="775" width="25" height="25" /> : <text x="292" y="795" fill={theme.dark}>—</text>}
       {resistanceIcon && <text x="312" y="795" fill={theme.dark} fontFamily="Arial, Helvetica, sans-serif" fontSize="15" fontWeight="850">−30</text>}
       <text x="442" y="769" fill={theme.dark} fontFamily="Arial, Helvetica, sans-serif" fontSize="10" fontWeight="850" letterSpacing="0.7">RETREAT</text>
-      {Array.from({ length: Math.min(Number(cardData.retreatCost) || 0, 5) }).map((_, index) => (
+      {Array.from({ length: Math.min(Number(cardData.retreatCost ?? 1), 5) }).map((_, index) => (
         <image key={index} href={getTypeIcon('normal')} xlinkHref={getTypeIcon('normal')} x={444 + index * 27} y="777" width="23" height="23" />
       ))}
 

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -11,6 +11,11 @@ const FULL_ART_Y = 30
 const FULL_ART_WIDTH = 600
 const FULL_ART_HEIGHT = 861
 
+const getRetreatCost = (value) => {
+  const cost = Number.parseInt(value ?? 1, 10)
+  return Number.isNaN(cost) ? 1 : Math.max(0, Math.min(cost, 5))
+}
+
 const getTextUnits = (text) => [...text].reduce((total, character) => (
   total + (/\p{Script=Han}|\p{Script=Hiragana}|\p{Script=Katakana}/u.test(character) ? 1 : 0.56)
 ), 0)
@@ -228,7 +233,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
         <rect x="45" y="808" width="570" height="75" rx="18" fill="#f5f8f5" fillOpacity="0.86" stroke="#d7dedc" strokeWidth="2" />
       </g>
       <text x="65" y="837" fill="#252b2c" fontFamily="Arial, Helvetica, sans-serif" fontSize="11" fontWeight="800" letterSpacing="0.8">RETREAT</text>
-      {Array.from({ length: Math.min(Number(cardData.retreatCost ?? 1), 5) }).map((_, index) => (
+      {Array.from({ length: getRetreatCost(cardData.retreatCost) }).map((_, index) => (
         <image key={index} href={getTypeIcon('normal')} xlinkHref={getTypeIcon('normal')} x={124 + index * 21} y="824" width="18" height="18" />
       ))}
       <text x="330" y="837" textAnchor="middle" fill="#303738" fontFamily="Arial, Helvetica, sans-serif" fontSize="11" fontWeight="750" letterSpacing="0.8">FAN-MADE • NOT FOR SALE</text>
@@ -451,7 +456,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
       {resistanceIcon ? <image href={resistanceIcon} xlinkHref={resistanceIcon} x="280" y="775" width="25" height="25" /> : <text x="292" y="795" fill={theme.dark}>—</text>}
       {resistanceIcon && <text x="312" y="795" fill={theme.dark} fontFamily="Arial, Helvetica, sans-serif" fontSize="15" fontWeight="850">−30</text>}
       <text x="442" y="769" fill={theme.dark} fontFamily="Arial, Helvetica, sans-serif" fontSize="10" fontWeight="850" letterSpacing="0.7">RETREAT</text>
-      {Array.from({ length: Math.min(Number(cardData.retreatCost ?? 1), 5) }).map((_, index) => (
+      {Array.from({ length: getRetreatCost(cardData.retreatCost) }).map((_, index) => (
         <image key={index} href={getTypeIcon('normal')} xlinkHref={getTypeIcon('normal')} x={444 + index * 27} y="777" width="23" height="23" />
       ))}
 

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -88,7 +88,8 @@ const CardForm = ({
             value={cardData.hp}
             onChange={(e) => {
               const hp = e.target.value.replace(/\D/g, '')
-              onInputChange('hp', Number(hp) > 9999 ? '9999' : hp.slice(0, 4))
+              const parsedHp = Number.parseInt(hp, 10)
+              onInputChange('hp', Number.isNaN(parsedHp) ? '' : String(Math.min(parsedHp, 9999)))
             }}
             placeholder="100"
             min="10"

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -259,7 +259,7 @@ const CardForm = ({
               <select
                 aria-label={t('retreatCost')}
                 value={cardData.retreatCost ?? 1}
-                onChange={(e) => onInputChange('retreatCost', parseInt(e.target.value))}
+                onChange={(e) => onInputChange('retreatCost', Number.parseInt(e.target.value, 10))}
               >
                 {[0, 1, 2, 3, 4, 5].map(cost => (
                   <option key={cost} value={cost}>{cost}</option>

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -86,7 +86,10 @@ const CardForm = ({
             id="pokemon-hp"
             type="number"
             value={cardData.hp}
-            onChange={(e) => onInputChange('hp', e.target.value.slice(0, 4))}
+            onChange={(e) => {
+              const hp = e.target.value
+              onInputChange('hp', Number(hp) > 9999 ? '9999' : hp.slice(0, 4))
+            }}
             placeholder="100"
             min="10"
             max="9999"

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -86,10 +86,10 @@ const CardForm = ({
             id="pokemon-hp"
             type="number"
             value={cardData.hp}
-            onChange={(e) => onInputChange('hp', e.target.value)}
+            onChange={(e) => onInputChange('hp', e.target.value.slice(0, 4))}
             placeholder="100"
             min="10"
-            max="999"
+            max="9999"
           />
         </div>
 
@@ -254,7 +254,7 @@ const CardForm = ({
               <label>{t('retreatCost')}</label>
               <select
                 aria-label={t('retreatCost')}
-                value={cardData.retreatCost || 1}
+                value={cardData.retreatCost ?? 1}
                 onChange={(e) => onInputChange('retreatCost', parseInt(e.target.value))}
               >
                 {[0, 1, 2, 3, 4, 5].map(cost => (

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -87,7 +87,7 @@ const CardForm = ({
             type="number"
             value={cardData.hp}
             onChange={(e) => {
-              const hp = e.target.value
+              const hp = e.target.value.replace(/\D/g, '')
               onInputChange('hp', Number(hp) > 9999 ? '9999' : hp.slice(0, 4))
             }}
             placeholder="100"


### PR DESCRIPTION
## 概要

Issue #8の機能改善として、逃げるコスト0と4桁HPに対応します。

## 変更内容

- 逃げるコストで0を選択した状態を保持するよう修正
- HP入力の上限を999から9999へ変更し、5桁目を受け付けないよう制限
- 通常・全面アート両レイアウトで、HPラベルと4桁の数値が重ならないよう配置を調整

## 原因

- 逃げるコストの値に論理ORを使用していたため、0が既定値1へ置き換わっていた
- HPラベルが3桁を前提とした固定位置に配置されていた

## 確認内容

- `npm run lint`
- `npm run build`
- ブラウザで逃げるコスト0の保持とアイコン非表示を確認
- ブラウザでHP 9999の入力制限と、通常・全面アート両方の表示を確認

Closes #8
