### PR TITLE
[codex] Issue #10のUI改善

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,5 @@
 - Poll for a Gemini Code Assist review submitted after the request time for up to five minutes. Treat the review as complete only when it covers the recorded head commit and all actionable comments have been evaluated.
 - If Gemini does not respond within five minutes, report the timeout and treat Gemini review as unavailable; do not imply that Gemini approved or completed the review.
 - Evaluate each Gemini comment against the repository's actual data flow and component contracts. Apply valid actionable feedback, and document why any rejected suggestion is unnecessary or harmful.
-- After pushing review fixes, request another Gemini review and repeat this workflow until there are no unresolved actionable comments, unless Gemini review is unavailable or the user explicitly asks to proceed without it.
+- Apply and push at most two rounds of fixes prompted by Gemini reviews. Count each pushed batch of review fixes as one round.
+- After the first review-fix round, request another Gemini review and repeat this workflow. After the second review-fix round, do not apply further Gemini suggestions or request another review automatically; ask the user whether another fix round is necessary.

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -275,6 +275,10 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
   })
   const weaknessIcon = cardData.weakness !== 'none' ? getTypeIcon(cardData.weakness) : null
   const resistanceIcon = cardData.resistance !== 'none' ? getTypeIcon(cardData.resistance) : null
+  const abilityAreaY = 519
+  const abilityAreaHeight = 221
+  const abilityContentHeight = 64
+  const abilitySlotHeight = abilityAreaHeight / Math.max(abilities.length, 1)
 
   return (
     <svg
@@ -409,19 +413,19 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
         NO. 001  ORIGINAL CREATURE  ·  HT: 1.2 m  ·  WT: 24.0 kg
       </text>
 
-      <rect x="48" y="519" width="564" height="221" rx="4" fill="#fff" fillOpacity="0.28" stroke={theme.dark} strokeOpacity="0.22" />
+      <rect x="48" y={abilityAreaY} width="564" height={abilityAreaHeight} rx="4" fill="#fff" fillOpacity="0.28" stroke={theme.dark} strokeOpacity="0.22" />
       {abilities.length === 0 ? (
         <text x="330" y="630" textAnchor="middle" fill={theme.dark} fillOpacity="0.6" fontFamily="Arial, Helvetica, sans-serif" fontSize="18">Add an ability to complete the card</text>
       ) : abilities.map((ability, index) => {
-        const abilityRowHeight = Math.min(73, 215 / Math.max(abilities.length, 1))
-        const y = 528 + index * abilityRowHeight
+        const y = abilityAreaY + index * abilitySlotHeight + (abilitySlotHeight - abilityContentHeight) / 2
+        const separatorY = abilityAreaY + index * abilitySlotHeight
         const cost = Math.min(Number(ability.energyCost) || 1, 5)
         const abilityX = 68 + cost * 32
         const abilityNameSize = Math.max(16, 23 - Math.max(0, getTextUnits(ability.name) - 11) * 0.85)
         const descriptionLines = wrapText(ability.description, Math.max(24, 52 - cost * 2.5), 2)
         return (
           <g key={`${ability.name}-${index}`}>
-            {index > 0 && <line x1="66" y1={y - 9} x2="594" y2={y - 9} stroke={theme.dark} strokeOpacity="0.35" strokeWidth="1.2" />}
+            {index > 0 && <line x1="66" y1={separatorY} x2="594" y2={separatorY} stroke={theme.dark} strokeOpacity="0.35" strokeWidth="1.2" />}
             {Array.from({ length: cost }).map((_, energyIndex) => (
               <image key={energyIndex} href={typeIcon} xlinkHref={typeIcon} x={68 + energyIndex * 32} y={y + 2} width="28" height="28" />
             ))}

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -33,8 +33,12 @@ const CardForm = ({
 
   return (
     <div className="card-form">
-      <fieldset className="form-group card-layout-group">
-        <legend className="group-label">{t('cardLayout')}</legend>
+      <div
+        className="form-group card-layout-group"
+        role="radiogroup"
+        aria-labelledby="card-layout-label"
+      >
+        <span id="card-layout-label" className="group-label">{t('cardLayout')}</span>
         <div className="layout-options">
           <label className="layout-option">
             <input
@@ -63,7 +67,7 @@ const CardForm = ({
             </span>
           </label>
         </div>
-      </fieldset>
+      </div>
 
       {/* ポケモン名入力 */}
       <div className="form-group pokemon-name-group">
@@ -132,7 +136,10 @@ const CardForm = ({
             onChange={onImageUpload}
             hidden
           />
-          <small>{t('recommendedImage')}</small>
+          <div className="image-upload-help">
+            <small>{t('recommendedImage')}</small>
+            <small>{t('imagePrivacyNotice')}</small>
+          </div>
           {imageError && (
             <div className="image-upload-error" role="alert">
               <span aria-hidden="true">!</span>

--- a/src/components/DownloadButton.jsx
+++ b/src/components/DownloadButton.jsx
@@ -126,7 +126,7 @@ const svgToPng = async (sourceSvg, includeFoil, foilPosition) => {
 
 const DownloadButton = ({ cardRef, cardData }) => {
   const [isGenerating, setIsGenerating] = useState(false)
-  const [includeFoil, setIncludeFoil] = useState(true)
+  const [includeFoil, setIncludeFoil] = useState(false)
   const [error, setError] = useState('')
   const [status, setStatus] = useState('')
   const { t } = useLanguage()

--- a/src/components/PokemonCardGenerator.css
+++ b/src/components/PokemonCardGenerator.css
@@ -152,11 +152,6 @@
 
 .card-layout-group {
   min-width: 0;
-  margin: 0;
-}
-
-.card-layout-group legend {
-  padding: 0;
 }
 
 .layout-options {
@@ -301,7 +296,12 @@
   background: #3a4955;
 }
 
-.image-upload-section small {
+.image-upload-help {
+  display: grid;
+  gap: 2px;
+}
+
+.image-upload-help small {
   color: var(--muted);
   line-height: 1.45;
 }

--- a/src/contexts/translations.js
+++ b/src/contexts/translations.js
@@ -62,7 +62,7 @@ export const translations = {
     pokemonDescriptionPlaceholder: "A brief description of your Pokemon",
 
     // ボタンテキスト
-    uploadImage: "Upload Image",
+    uploadImage: "Choose Image",
     changeImage: "Change Image",
     imageAdjustment: "Image framing",
     imageZoom: "Zoom",
@@ -81,6 +81,7 @@ export const translations = {
     // 情報テキスト
     recommendedImage:
       "JPG, PNG or WebP · up to 8 MB · portrait images work best",
+    imagePrivacyNotice: "Your image is processed only in this browser and is not uploaded to a server.",
     downloadInfo: "Exports the exact preview at 1320 × 1842 px",
 
     // ポケモンタイプ
@@ -225,7 +226,7 @@ export const translations = {
     pokemonDescriptionPlaceholder: "ポケモンの簡単な説明",
 
     // ボタンテキスト
-    uploadImage: "画像をアップロード",
+    uploadImage: "画像を選択",
     changeImage: "画像を変更",
     imageAdjustment: "画像の表示調整",
     imageZoom: "拡大・縮小",
@@ -243,6 +244,7 @@ export const translations = {
 
     // 情報テキスト
     recommendedImage: "JPG・PNG・WebP／8MBまで／縦長画像がおすすめです",
+    imagePrivacyNotice: "※画像はサーバーにアップロードされません",
     downloadInfo: "プレビューと同じ内容を1320 × 1842 pxで保存します",
 
     // ポケモンタイプ

--- a/src/contexts/translations.js
+++ b/src/contexts/translations.js
@@ -244,7 +244,7 @@ export const translations = {
 
     // 情報テキスト
     recommendedImage: "JPG・PNG・WebP／8MBまで／縦長画像がおすすめです",
-    imagePrivacyNotice: "※画像はサーバーにアップロードされません",
+    imagePrivacyNotice: "※画像はサーバーへ送信されず、ブラウザ内でのみ処理されます",
     downloadInfo: "プレビューと同じ内容を1320 × 1842 pxで保存します",
 
     // ポケモンタイプ


### PR DESCRIPTION
## 概要

Issue #10で依頼されたUI改善と運用ルール変更を反映します。

Closes #10

## 変更内容

- PNG保存時の光沢エフェクトをデフォルトOFFに変更
- 画像選択ボタンの文言を変更し、画像がブラウザ内でのみ処理される旨を追記
- スマホ表示でカードレイアウトの見出しと選択肢が重なる問題を修正
- 通常レイアウトの技を技領域内で縦中央・等間隔に配置
- Geminiレビュー後の自動修正を最大2回に制限するルールを追加

## 原因と対応

カードレイアウト見出しは`fieldset`と`legend`のブラウザ固有レイアウトにより、狭い画面で外枠と干渉していました。通常のグループ要素と`radiogroup`へ変更し、他の入力カードと同じ構造に統一しています。

技の配置は領域上端から固定間隔で並べていたため、件数が少ない場合に上寄せになっていました。技領域を件数分の等しいスロットへ分割し、各技をスロット中央へ配置する方式に変更しています。

## 確認内容

- `npm run lint`
- `npm run build`
- 390×844pxでのスマホ表示確認
- 通常レイアウトで技1〜3件の中央・等間隔配置確認
- ブラウザコンソールエラーがないことを確認