### PR TITLE
[codex] 入力可能な文字数と行数を制限

### DIFF
--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -190,7 +190,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
         {cardData.name || 'Untitled'}
       </text>
       <text x="548" y="116" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
-        <tspan fill="#303637" fontSize="18" fontWeight="800" dy="-6">HP</tspan>
+        <tspan fill="#303637" fontSize="21" fontWeight="900" dy="-6">HP</tspan>
         <tspan fill="#111516" fontSize="35" fontWeight="850" dy="6" dx="5">{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="556" y="75" width="48" height="48" />
@@ -379,7 +379,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
         {cardData.name || 'Untitled'}
       </text>
       <text x="558" y="97" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
-        <tspan fill={theme.dark} fontSize="18" fontWeight="850" dy="-3">HP</tspan>
+        <tspan fill={theme.dark} fontSize="21" fontWeight="900" dy="-3">HP</tspan>
         <tspan fill="#111" fontSize="36" fontWeight="900" letterSpacing="-1" dy="3" dx="5">{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="566" y="57" width="46" height="46" />

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -200,7 +200,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
         const cost = Math.min(Number(ability.energyCost) || 1, 5)
         const abilityX = 75 + cost * 29
         const abilityNameSize = Math.max(16, 24 - Math.max(0, getTextUnits(ability.name) - 11) * 0.85)
-        const descriptionLines = wrapText(ability.description, Math.max(23, 49 - cost * 2.4), 2)
+        const descriptionLines = wrapText(ability.description, Math.max(23, 49 - cost * 2.4), 1)
 
         return (
           <g key={`${ability.name}-${index}`} filter="url(#full-art-panel-shadow)">
@@ -422,7 +422,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
         const cost = Math.min(Number(ability.energyCost) || 1, 5)
         const abilityX = 68 + cost * 32
         const abilityNameSize = Math.max(16, 23 - Math.max(0, getTextUnits(ability.name) - 11) * 0.85)
-        const descriptionLines = wrapText(ability.description, Math.max(24, 52 - cost * 2.5), 2)
+        const descriptionLines = wrapText(ability.description, Math.max(24, 52 - cost * 2.5), 1)
         return (
           <g key={`${ability.name}-${index}`}>
             {index > 0 && <line x1="66" y1={separatorY} x2="594" y2={separatorY} stroke={theme.dark} strokeOpacity="0.35" strokeWidth="1.2" />}

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -78,7 +78,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
   const typeIcon = getTypeIcon(cardData.type)
   const abilities = cardData.abilities.filter((ability) => ability.name).slice(0, 2)
   const nameUnits = getTextUnits(cardData.name || '')
-  const nameSize = Math.max(22, 38 - Math.max(0, nameUnits - 10) * 1.45)
+  const nameSize = Math.max(22, 38 - Math.max(0, nameUnits - 9) * 2.5)
   const raritySymbols = { common: '○', uncommon: '●', rare: '◆', holo: '★' }
   const photo = getCoverLayout(imageAdjustment, {
     x: FULL_ART_X,
@@ -199,7 +199,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
         const y = abilityStartY + index * 101
         const cost = Math.min(Number(ability.energyCost) || 1, 5)
         const abilityX = 75 + cost * 29
-        const abilityNameSize = Math.max(16, 24 - Math.max(0, getTextUnits(ability.name) - 11) * 0.85)
+        const abilityNameSize = Math.max(14, 24 - Math.max(0, getTextUnits(ability.name) - 11) * 1.1)
         const descriptionLines = wrapText(ability.description, 28, 1)
 
         return (
@@ -265,7 +265,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
   const typeIcon = getTypeIcon(cardData.type)
   const abilities = cardData.abilities.filter((ability) => ability.name).slice(0, 3)
   const nameUnits = getTextUnits(cardData.name || '')
-  const nameSize = Math.max(21, 35 - Math.max(0, nameUnits - 10) * 1.4)
+  const nameSize = Math.max(21, 35 - Math.max(0, nameUnits - 9) * 1.5)
   const raritySymbols = { common: '○', uncommon: '●', rare: '◆', holo: '★' }
   const image = getCoverLayout(imageAdjustment, {
     x: ART_X,
@@ -421,7 +421,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
         const separatorY = abilityAreaY + index * abilitySlotHeight
         const cost = Math.min(Number(ability.energyCost) || 1, 5)
         const abilityX = 68 + cost * 32
-        const abilityNameSize = Math.max(16, 23 - Math.max(0, getTextUnits(ability.name) - 11) * 0.85)
+        const abilityNameSize = Math.max(14, 23 - Math.max(0, getTextUnits(ability.name) - 11))
         const descriptionLines = wrapText(ability.description, 28, 1)
         return (
           <g key={`${ability.name}-${index}`}>

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -190,7 +190,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
         {cardData.name || 'Untitled'}
       </text>
       <text x="548" y="116" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
-        <tspan fill="#303637" fontSize="21" fontWeight="900" dy="-6">HP</tspan>
+        <tspan fill="#303637" fontSize="25" fontWeight="900" dy="-6">HP</tspan>
         <tspan fill="#111516" fontSize="35" fontWeight="850" dy="6" dx="5">{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="556" y="75" width="48" height="48" />
@@ -379,7 +379,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
         {cardData.name || 'Untitled'}
       </text>
       <text x="558" y="97" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
-        <tspan fill={theme.dark} fontSize="21" fontWeight="900" dy="-3">HP</tspan>
+        <tspan fill={theme.dark} fontSize="25" fontWeight="900" dy="-3">HP</tspan>
         <tspan fill="#111" fontSize="36" fontWeight="900" letterSpacing="-1" dy="3" dx="5">{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="566" y="57" width="46" height="46" />

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -190,7 +190,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
         {cardData.name || 'Untitled'}
       </text>
       <text x="548" y="116" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
-        <tspan fill="#303637" fontSize="17" fontWeight="800" dy="-6">HP</tspan>
+        <tspan fill="#303637" fontSize="18" fontWeight="800" dy="-6">HP</tspan>
         <tspan fill="#111516" fontSize="35" fontWeight="850" dy="6" dx="5">{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="556" y="75" width="48" height="48" />
@@ -379,7 +379,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
         {cardData.name || 'Untitled'}
       </text>
       <text x="558" y="97" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
-        <tspan fill={theme.dark} fontSize="15" fontWeight="850" dy="-3">HP</tspan>
+        <tspan fill={theme.dark} fontSize="18" fontWeight="850" dy="-3">HP</tspan>
         <tspan fill="#111" fontSize="36" fontWeight="900" letterSpacing="-1" dy="3" dx="5">{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="566" y="57" width="46" height="46" />

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -190,7 +190,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
         {cardData.name || 'Untitled'}
       </text>
       <text x="548" y="116" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
-        <tspan fill="#303637" fontSize="15" fontWeight="800" dy="-6">HP</tspan>
+        <tspan fill="#303637" fontSize="17" fontWeight="800" dy="-6">HP</tspan>
         <tspan fill="#111516" fontSize="35" fontWeight="850" dy="6" dx="5">{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="556" y="75" width="48" height="48" />
@@ -199,8 +199,10 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
         const y = abilityStartY + index * 101
         const cost = Math.min(Number(ability.energyCost) || 1, 5)
         const abilityX = 75 + cost * 29
-        const abilityNameSize = Math.max(14, 24 - Math.max(0, getTextUnits(ability.name) - 11) * 1.1)
-        const descriptionLines = wrapText(ability.description, 28, 1)
+        const abilityNameSize = Math.max(10, 24 - Math.max(0, getTextUnits(ability.name) - 11) * 0.75)
+        const descriptionUnits = getTextUnits(ability.description)
+        const descriptionSize = Math.max(10, 13 - Math.max(0, descriptionUnits - 28) * 0.35)
+        const descriptionLines = wrapText(ability.description, 35, 1)
 
         return (
           <g key={`${ability.name}-${index}`} filter="url(#full-art-panel-shadow)">
@@ -223,7 +225,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
               lineHeight="16"
               fill="#2c3233"
               fontFamily="Arial, Helvetica, sans-serif"
-              fontSize="13"
+              fontSize={descriptionSize}
             />
           </g>
         )
@@ -377,7 +379,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
         {cardData.name || 'Untitled'}
       </text>
       <text x="558" y="97" textAnchor="end" fontFamily="Arial, Helvetica, sans-serif">
-        <tspan fill={theme.dark} fontSize="13" fontWeight="850" dy="-3">HP</tspan>
+        <tspan fill={theme.dark} fontSize="15" fontWeight="850" dy="-3">HP</tspan>
         <tspan fill="#111" fontSize="36" fontWeight="900" letterSpacing="-1" dy="3" dx="5">{cardData.hp || '—'}</tspan>
       </text>
       <image href={typeIcon} xlinkHref={typeIcon} x="566" y="57" width="46" height="46" />
@@ -421,8 +423,8 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
         const separatorY = abilityAreaY + index * abilitySlotHeight
         const cost = Math.min(Number(ability.energyCost) || 1, 5)
         const abilityX = 68 + cost * 32
-        const abilityNameSize = Math.max(14, 23 - Math.max(0, getTextUnits(ability.name) - 11))
-        const descriptionLines = wrapText(ability.description, 28, 1)
+        const abilityNameSize = Math.max(10, 23 - Math.max(0, getTextUnits(ability.name) - 11) * 0.68)
+        const descriptionLines = wrapText(ability.description, 35, 1)
         return (
           <g key={`${ability.name}-${index}`}>
             {index > 0 && <line x1="66" y1={separatorY} x2="594" y2={separatorY} stroke={theme.dark} strokeOpacity="0.35" strokeWidth="1.2" />}

--- a/src/components/CardArtwork.jsx
+++ b/src/components/CardArtwork.jsx
@@ -200,7 +200,7 @@ const FullArtCard = ({ cardData, imagePreview, imageAdjustment, svgRef }) => {
         const cost = Math.min(Number(ability.energyCost) || 1, 5)
         const abilityX = 75 + cost * 29
         const abilityNameSize = Math.max(16, 24 - Math.max(0, getTextUnits(ability.name) - 11) * 0.85)
-        const descriptionLines = wrapText(ability.description, Math.max(23, 49 - cost * 2.4), 1)
+        const descriptionLines = wrapText(ability.description, 28, 1)
 
         return (
           <g key={`${ability.name}-${index}`} filter="url(#full-art-panel-shadow)">
@@ -422,7 +422,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
         const cost = Math.min(Number(ability.energyCost) || 1, 5)
         const abilityX = 68 + cost * 32
         const abilityNameSize = Math.max(16, 23 - Math.max(0, getTextUnits(ability.name) - 11) * 0.85)
-        const descriptionLines = wrapText(ability.description, Math.max(24, 52 - cost * 2.5), 1)
+        const descriptionLines = wrapText(ability.description, 28, 1)
         return (
           <g key={`${ability.name}-${index}`}>
             {index > 0 && <line x1="66" y1={separatorY} x2="594" y2={separatorY} stroke={theme.dark} strokeOpacity="0.35" strokeWidth="1.2" />}
@@ -465,7 +465,7 @@ const CardArtwork = ({ cardData, layoutMode, imagePreview, imageAdjustment, svgR
       ))}
 
       <TextLines
-        lines={wrapText(cardData.description, 65, 2)}
+        lines={wrapText(cardData.description, 40, 2)}
         x="330"
         y="830"
         lineHeight="17"

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -2,9 +2,9 @@ import { useRef } from 'react'
 import { useLanguage } from '../contexts/useLanguage'
 
 const INPUT_LIMITS = {
-  pokemonName: 12,
-  abilityName: 20,
-  abilityDescription: 70,
+  pokemonName: 13,
+  abilityName: 30,
+  abilityDescription: 35,
   pokemonDescription: 80,
 }
 

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -1,6 +1,28 @@
 import { useRef } from 'react'
 import { useLanguage } from '../contexts/useLanguage'
 
+const INPUT_LIMITS = {
+  pokemonName: 16,
+  abilityName: 16,
+  abilityDescription: 32,
+  pokemonDescription: 100,
+}
+
+const CharacterCount = ({ currentLength, maxLength, messageId, t }) => {
+  const isAtLimit = currentLength >= maxLength
+
+  return (
+    <div className={`character-count${isAtLimit ? ' is-at-limit' : ''}`}>
+      <span id={messageId} role="status" aria-live="polite">
+        {isAtLimit ? t('characterLimitReached') : ''}
+      </span>
+      <span>
+        {currentLength} / {maxLength}
+      </span>
+    </div>
+  )
+}
+
 // カード入力フォームコンポーネント - 各入力項目を管理
 const CardForm = ({ 
   cardData, 
@@ -76,9 +98,19 @@ const CardForm = ({
           id="pokemon-name"
           type="text"
           value={cardData.name}
-          onChange={(e) => onInputChange('name', e.target.value)}
+          onChange={(e) => onInputChange(
+            'name',
+            e.target.value.slice(0, INPUT_LIMITS.pokemonName),
+          )}
           placeholder={t('enterPokemonName')}
-          maxLength={20}
+          maxLength={INPUT_LIMITS.pokemonName}
+          aria-describedby="pokemon-name-limit"
+        />
+        <CharacterCount
+          currentLength={cardData.name.length}
+          maxLength={INPUT_LIMITS.pokemonName}
+          messageId="pokemon-name-limit"
+          t={t}
         />
       </div>
 
@@ -184,12 +216,18 @@ const CardForm = ({
             <div key={index} className="ability-group">
               <div className="ability-header">
                 <input
+                  id={`ability-name-${index}`}
                   aria-label={`${t('abilityName')} ${index + 1}`}
                   type="text"
                   value={ability.name}
-                  onChange={(e) => onAbilityChange(index, 'name', e.target.value)}
+                  onChange={(e) => onAbilityChange(
+                    index,
+                    'name',
+                    e.target.value.slice(0, INPUT_LIMITS.abilityName),
+                  )}
                   placeholder={t('abilityName')}
-                  maxLength={20}
+                  maxLength={INPUT_LIMITS.abilityName}
+                  aria-describedby={`ability-name-${index}-limit`}
                 />
                 {/* 技が複数ある場合は削除ボタンを表示 */}
                 {cardData.abilities.length > 1 && (
@@ -203,6 +241,12 @@ const CardForm = ({
                   </button>
                 )}
               </div>
+              <CharacterCount
+                currentLength={ability.name.length}
+                maxLength={INPUT_LIMITS.abilityName}
+                messageId={`ability-name-${index}-limit`}
+                t={t}
+              />
               
               {/* エネルギーコストとダメージの入力行 */}
               <div className="ability-stats">
@@ -233,13 +277,25 @@ const CardForm = ({
                 </div>
               </div>
               
-              <textarea
+              <input
+                id={`ability-description-${index}`}
                 aria-label={`${t('abilityDescription')} ${index + 1}`}
+                type="text"
                 value={ability.description}
-                onChange={(e) => onAbilityChange(index, 'description', e.target.value)}
+                onChange={(e) => onAbilityChange(
+                  index,
+                  'description',
+                  e.target.value.slice(0, INPUT_LIMITS.abilityDescription),
+                )}
                 placeholder={t('abilityDescription')}
-                maxLength={60}
-                rows={2}
+                maxLength={INPUT_LIMITS.abilityDescription}
+                aria-describedby={`ability-description-${index}-limit`}
+              />
+              <CharacterCount
+                currentLength={ability.description.length}
+                maxLength={INPUT_LIMITS.abilityDescription}
+                messageId={`ability-description-${index}-limit`}
+                t={t}
               />
             </div>
           ))}
@@ -311,10 +367,24 @@ const CardForm = ({
         <textarea
           id="pokemon-description"
           value={cardData.description}
-          onChange={(e) => onInputChange('description', e.target.value)}
+          onChange={(e) => {
+            const twoLineValue = e.target.value
+              .slice(0, INPUT_LIMITS.pokemonDescription)
+              .split(/\r?\n/)
+              .slice(0, 2)
+              .join('\n')
+            onInputChange('description', twoLineValue)
+          }}
           placeholder={t('pokemonDescriptionPlaceholder')}
-          maxLength={100}
-          rows={3}
+          maxLength={INPUT_LIMITS.pokemonDescription}
+          rows={2}
+          aria-describedby="pokemon-description-limit"
+        />
+        <CharacterCount
+          currentLength={cardData.description.length}
+          maxLength={INPUT_LIMITS.pokemonDescription}
+          messageId="pokemon-description-limit"
+          t={t}
         />
       </div>
     </div>

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -8,7 +8,7 @@ const INPUT_LIMITS = {
   pokemonDescription: 100,
 }
 
-const CharacterCount = ({ currentLength, maxLength, messageId, t }) => {
+const CharacterCount = ({ currentLength = 0, maxLength, messageId, t }) => {
   const isAtLimit = currentLength >= maxLength
 
   return (
@@ -98,16 +98,13 @@ const CardForm = ({
           id="pokemon-name"
           type="text"
           value={cardData.name}
-          onChange={(e) => onInputChange(
-            'name',
-            e.target.value.slice(0, INPUT_LIMITS.pokemonName),
-          )}
+          onChange={(e) => onInputChange('name', e.target.value)}
           placeholder={t('enterPokemonName')}
           maxLength={INPUT_LIMITS.pokemonName}
           aria-describedby="pokemon-name-limit"
         />
         <CharacterCount
-          currentLength={cardData.name.length}
+          currentLength={cardData.name?.length}
           maxLength={INPUT_LIMITS.pokemonName}
           messageId="pokemon-name-limit"
           t={t}
@@ -220,11 +217,7 @@ const CardForm = ({
                   aria-label={`${t('abilityName')} ${index + 1}`}
                   type="text"
                   value={ability.name}
-                  onChange={(e) => onAbilityChange(
-                    index,
-                    'name',
-                    e.target.value.slice(0, INPUT_LIMITS.abilityName),
-                  )}
+                  onChange={(e) => onAbilityChange(index, 'name', e.target.value)}
                   placeholder={t('abilityName')}
                   maxLength={INPUT_LIMITS.abilityName}
                   aria-describedby={`ability-name-${index}-limit`}
@@ -242,7 +235,7 @@ const CardForm = ({
                 )}
               </div>
               <CharacterCount
-                currentLength={ability.name.length}
+                currentLength={ability.name?.length}
                 maxLength={INPUT_LIMITS.abilityName}
                 messageId={`ability-name-${index}-limit`}
                 t={t}
@@ -282,17 +275,13 @@ const CardForm = ({
                 aria-label={`${t('abilityDescription')} ${index + 1}`}
                 type="text"
                 value={ability.description}
-                onChange={(e) => onAbilityChange(
-                  index,
-                  'description',
-                  e.target.value.slice(0, INPUT_LIMITS.abilityDescription),
-                )}
+                onChange={(e) => onAbilityChange(index, 'description', e.target.value)}
                 placeholder={t('abilityDescription')}
                 maxLength={INPUT_LIMITS.abilityDescription}
                 aria-describedby={`ability-description-${index}-limit`}
               />
               <CharacterCount
-                currentLength={ability.description.length}
+                currentLength={ability.description?.length}
                 maxLength={INPUT_LIMITS.abilityDescription}
                 messageId={`ability-description-${index}-limit`}
                 t={t}
@@ -369,7 +358,6 @@ const CardForm = ({
           value={cardData.description}
           onChange={(e) => {
             const twoLineValue = e.target.value
-              .slice(0, INPUT_LIMITS.pokemonDescription)
               .split(/\r?\n/)
               .slice(0, 2)
               .join('\n')
@@ -381,7 +369,7 @@ const CardForm = ({
           aria-describedby="pokemon-description-limit"
         />
         <CharacterCount
-          currentLength={cardData.description.length}
+          currentLength={cardData.description?.length}
           maxLength={INPUT_LIMITS.pokemonDescription}
           messageId="pokemon-description-limit"
           t={t}

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -2,10 +2,10 @@ import { useRef } from 'react'
 import { useLanguage } from '../contexts/useLanguage'
 
 const INPUT_LIMITS = {
-  pokemonName: 16,
-  abilityName: 16,
-  abilityDescription: 40,
-  pokemonDescription: 100,
+  pokemonName: 9,
+  abilityName: 11,
+  abilityDescription: 28,
+  pokemonDescription: 80,
 }
 
 const CharacterCount = ({ currentLength = 0, maxLength, messageId, t }) => {

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -2,9 +2,9 @@ import { useRef } from 'react'
 import { useLanguage } from '../contexts/useLanguage'
 
 const INPUT_LIMITS = {
-  pokemonName: 9,
-  abilityName: 11,
-  abilityDescription: 28,
+  pokemonName: 12,
+  abilityName: 20,
+  abilityDescription: 70,
   pokemonDescription: 80,
 }
 

--- a/src/components/CardForm.jsx
+++ b/src/components/CardForm.jsx
@@ -4,7 +4,7 @@ import { useLanguage } from '../contexts/useLanguage'
 const INPUT_LIMITS = {
   pokemonName: 16,
   abilityName: 16,
-  abilityDescription: 32,
+  abilityDescription: 40,
   pokemonDescription: 100,
 }
 
@@ -357,11 +357,10 @@ const CardForm = ({
           id="pokemon-description"
           value={cardData.description}
           onChange={(e) => {
-            const twoLineValue = e.target.value
-              .split(/\r?\n/)
-              .slice(0, 2)
-              .join('\n')
-            onInputChange('description', twoLineValue)
+            const lines = e.target.value.split(/\r?\n/)
+            if (lines.length <= 2) {
+              onInputChange('description', e.target.value)
+            }
           }}
           placeholder={t('pokemonDescriptionPlaceholder')}
           maxLength={INPUT_LIMITS.pokemonDescription}

--- a/src/components/PokemonCardGenerator.css
+++ b/src/components/PokemonCardGenerator.css
@@ -275,6 +275,31 @@
   box-shadow: 0 0 0 3px rgba(44, 110, 170, 0.13);
 }
 
+.character-count {
+  display: flex;
+  min-height: 1.25rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 0.7rem;
+  line-height: 1.35;
+}
+
+.character-count > :first-child {
+  flex: 1;
+}
+
+.character-count > :last-child {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.character-count.is-at-limit {
+  color: #9b342b;
+  font-weight: 700;
+}
+
 .image-upload-section {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -433,7 +458,15 @@
   display: flex;
   gap: 9px;
   align-items: center;
+  margin-bottom: 0;
+}
+
+.ability-header + .character-count {
   margin-bottom: 10px;
+}
+
+.ability-group > .character-count:last-child {
+  margin-top: 4px;
 }
 
 .ability-header input {

--- a/src/contexts/translations.js
+++ b/src/contexts/translations.js
@@ -114,7 +114,7 @@ export const translations = {
         abilities: [
           {
             name: "Fire Blast",
-            description: "Deals massive fire damage to opponents.",
+            description: "Deals heavy fire damage.",
           },
           { name: "Heat Wave", description: "Burns all nearby enemies." },
         ],
@@ -123,20 +123,20 @@ export const translations = {
       aquaflow: {
         name: "Aquaflow",
         abilities: [
-          { name: "Tidal Wave", description: "Creates massive water attacks." },
+          { name: "Tidal Wave", description: "Makes strong water attacks." },
         ],
         description: "A graceful water Pokemon that controls ocean currents.",
       },
       thunderstrike: {
-        name: "Thunderstrike",
+        name: "Thunder",
         abilities: [
           {
-            name: "Lightning Bolt",
-            description: "Strikes with pure electric energy.",
+            name: "Lightning",
+            description: "Uses pure electric energy.",
           },
           {
-            name: "Static Shield",
-            description: "Creates protective electric barriers.",
+            name: "Barrier",
+            description: "Creates an electric barrier.",
           },
         ],
         description: "An electric Pokemon crackling with storm energy.",
@@ -145,9 +145,9 @@ export const translations = {
 
     // デフォルトカードデータ
     defaultCard: {
-      name: "Custom Pokemon",
-      ability: "Custom Ability",
-      abilityDescription: "Your custom ability description.",
+      name: "Pokemon",
+      ability: "My Ability",
+      abilityDescription: "Describe your ability.",
       description: "A unique and original Pokemon created by you!",
     },
 

--- a/src/contexts/translations.js
+++ b/src/contexts/translations.js
@@ -60,6 +60,7 @@ export const translations = {
     abilityName: "Ability name",
     abilityDescription: "Ability description",
     pokemonDescriptionPlaceholder: "A brief description of your Pokemon",
+    characterLimitReached: "Character limit reached. No more text can be entered.",
 
     // ボタンテキスト
     uploadImage: "Choose Image",
@@ -224,6 +225,7 @@ export const translations = {
     abilityName: "技名",
     abilityDescription: "技の説明",
     pokemonDescriptionPlaceholder: "ポケモンの簡単な説明",
+    characterLimitReached: "文字数の上限に達したため、これ以上入力できません。",
 
     // ボタンテキスト
     uploadImage: "画像を選択",


### PR DESCRIPTION
## 変更内容

- ポケモン名・技名・技説明・ポケモン説明に固定の文字数上限を追加
- 技説明を1行、ポケモン説明を2行までに制限
- 各入力欄に文字数カウンターを表示し、上限到達時に追加入力できない旨を日英で表示
- カードプレビューの技説明も1行表示に統一

## 背景

入力文字数や行数に制限がなく、長いテキストによってカード表示が崩れる問題を防止します。

Closes #12

## 確認内容

- `npm run lint`
- `npm run build`
- ブラウザで各文字数上限、警告表示、技説明1行、ポケモン説明2行を確認
- ブラウザコンソールに警告・エラーがないことを確認
