### PR TITLE
[codex] 最後のカード入力をブラウザに保存

### DIFF
--- a/src/components/PokemonCardGenerator.jsx
+++ b/src/components/PokemonCardGenerator.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import PokemonCard from './PokemonCard'
 import CardForm from './CardForm'
 import DownloadButton from './DownloadButton'
@@ -13,38 +13,127 @@ const initialImageAdjustment = {
   height: 0,
 }
 
+const cardDraftStorageKey = 'pokemonCardDraft'
+
+const createInitialCardData = (t) => ({
+  name: t('defaultCard.name'),
+  hp: '100',
+  type: 'normal',
+  image: null,
+  abilities: [
+    {
+      name: t('defaultCard.ability'),
+      description: t('defaultCard.abilityDescription'),
+      energyCost: 1,
+      damage: '',
+    },
+  ],
+  description: t('defaultCard.description'),
+  weakness: 'none',
+  resistance: 'none',
+  retreatCost: 1,
+  cardNumber: '001/100',
+  rarity: 'common',
+})
+
+const isString = (value) => typeof value === 'string'
+const isFiniteNumber = (value) => typeof value === 'number' && Number.isFinite(value)
+
+const isSavedCardData = (cardData) => (
+  cardData
+  && isString(cardData.name)
+  && isString(cardData.hp)
+  && isString(cardData.type)
+  && Array.isArray(cardData.abilities)
+  && cardData.abilities.length >= 1
+  && cardData.abilities.length <= 3
+  && cardData.abilities.every((ability) => (
+    ability
+    && isString(ability.name)
+    && isString(ability.description)
+    && isFiniteNumber(ability.energyCost)
+    && isString(ability.damage)
+  ))
+  && isString(cardData.description)
+  && isString(cardData.weakness)
+  && isString(cardData.resistance)
+  && isFiniteNumber(cardData.retreatCost)
+  && isString(cardData.cardNumber)
+  && isString(cardData.rarity)
+)
+
+const isSavedImageAdjustment = (adjustment) => (
+  adjustment
+  && ['x', 'y', 'zoom', 'width', 'height'].every((field) => isFiniteNumber(adjustment[field]))
+)
+
+const loadSavedDraft = () => {
+  try {
+    const savedDraft = JSON.parse(localStorage.getItem(cardDraftStorageKey))
+    if (
+      !savedDraft
+      || !isSavedCardData(savedDraft.cardData)
+      || !isSavedImageAdjustment(savedDraft.imageAdjustment)
+      || !['standard', 'fullArt'].includes(savedDraft.layoutMode)
+    ) {
+      return null
+    }
+
+    return {
+      ...savedDraft,
+      cardData: { ...savedDraft.cardData, image: null },
+    }
+  } catch {
+    return null
+  }
+}
+
 // メインのポケモンカードジェネレーターコンポーネント
 const PokemonCardGenerator = () => {
   const { t } = useLanguage() // 翻訳機能とユーザーの言語設定を取得
-  
-  // カードデータの状態管理 - 初期値は言語に応じて設定
-  const [cardData, setCardData] = useState({
-    name: t('defaultCard.name'),
-    hp: '100',
-    type: 'normal',
-    image: null,
-    abilities: [
-      { 
-        name: t('defaultCard.ability'), 
-        description: t('defaultCard.abilityDescription'),
-        energyCost: 1,
-        damage: ''
-      }
-    ],
-    description: t('defaultCard.description'),
-    weakness: 'none',
-    resistance: 'none',
-    retreatCost: 1,
-    cardNumber: '001/100',
-    rarity: 'common'
-  })
+  const initialCardData = createInitialCardData(t)
+  const savedDraftRef = useRef(undefined)
+  if (savedDraftRef.current === undefined) {
+    savedDraftRef.current = loadSavedDraft()
+  }
+  const savedDraft = savedDraftRef.current
+
+  // カードデータの状態管理 - 保存内容がなければ言語に応じた初期値を使用
+  const [cardData, setCardData] = useState(() => savedDraft?.cardData ?? initialCardData)
 
   const [imagePreview, setImagePreview] = useState(null)
-  const [imageAdjustment, setImageAdjustment] = useState(initialImageAdjustment)
-  const [layoutMode, setLayoutMode] = useState('standard')
+  const [imageAdjustment, setImageAdjustment] = useState(
+    () => savedDraft?.imageAdjustment ?? initialImageAdjustment,
+  )
+  const [layoutMode, setLayoutMode] = useState(() => savedDraft?.layoutMode ?? 'standard')
   const [imageError, setImageError] = useState('')
   const cardRef = useRef(null)
   const imageUploadIdRef = useRef(0)
+  const isInitialRenderRef = useRef(true)
+  const skipNextSaveRef = useRef(false)
+
+  useEffect(() => {
+    if (isInitialRenderRef.current) {
+      isInitialRenderRef.current = false
+      return
+    }
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false
+      return
+    }
+
+    const cardDataWithoutImage = { ...cardData }
+    delete cardDataWithoutImage.image
+    try {
+      localStorage.setItem(cardDraftStorageKey, JSON.stringify({
+        cardData: cardDataWithoutImage,
+        imageAdjustment,
+        layoutMode,
+      }))
+    } catch {
+      // 保存できない環境でもカード編集は継続できるようにする
+    }
+  }, [cardData, imageAdjustment, layoutMode])
 
   // サンプルカードのデータ - 現在の言語に基づいて動的に取得
   const getSampleCards = () => {
@@ -205,26 +294,13 @@ const PokemonCardGenerator = () => {
   // カードリセット処理 - 言語に応じたデフォルト値に戻す
   const resetCard = () => {
     imageUploadIdRef.current += 1
-    setCardData({
-      name: t('defaultCard.name'),
-      hp: '100',
-      type: 'normal',
-      image: null,
-      abilities: [
-        { 
-          name: t('defaultCard.ability'), 
-          description: t('defaultCard.abilityDescription'),
-          energyCost: 1,
-          damage: ''
-        }
-      ],
-      description: t('defaultCard.description'),
-      weakness: 'none',
-      resistance: 'none',
-      retreatCost: 1,
-      cardNumber: '001/100',
-      rarity: 'common'
-    })
+    skipNextSaveRef.current = true
+    try {
+      localStorage.removeItem(cardDraftStorageKey)
+    } catch {
+      // 削除できない環境でも画面上のリセットは継続する
+    }
+    setCardData(createInitialCardData(t))
     setImagePreview(null)
     setImageAdjustment(initialImageAdjustment)
     setLayoutMode('standard')

--- a/src/components/PokemonCardGenerator.jsx
+++ b/src/components/PokemonCardGenerator.jsx
@@ -37,12 +37,12 @@ const createInitialCardData = (t) => ({
   rarity: 'common',
 })
 
-const defaultCardDataByLanguage = Object.values(translations).map(({ defaultCard }) => ({
-  ...createInitialCardData((key) => {
+const defaultCardDataByLanguage = Object.values(translations).map(({ defaultCard }) => (
+  createInitialCardData((key) => {
     const defaultCardKey = key.split('.')[1]
-    return defaultCard[defaultCardKey]
-  }),
-}))
+    return defaultCard?.[defaultCardKey] ?? ''
+  })
+))
 
 const isString = (value) => typeof value === 'string'
 const isFiniteNumber = (value) => typeof value === 'number' && Number.isFinite(value)
@@ -70,11 +70,6 @@ const isSavedCardData = (cardData) => (
   && isString(cardData.rarity)
 )
 
-const isSavedImageAdjustment = (adjustment) => (
-  adjustment
-  && ['x', 'y', 'zoom', 'width', 'height'].every((field) => isFiniteNumber(adjustment[field]))
-)
-
 const isSameCardData = (cardData, otherCardData) => (
   cardData.name === otherCardData.name
   && cardData.hp === otherCardData.hp
@@ -97,12 +92,8 @@ const isSameCardData = (cardData, otherCardData) => (
   })
 )
 
-const isInitialDraft = (cardData, imageAdjustment, layoutMode) => (
+const isInitialDraft = (cardData, layoutMode) => (
   layoutMode === 'standard'
-  && isSavedImageAdjustment(imageAdjustment)
-  && Object.entries(initialImageAdjustment).every(
-    ([field, value]) => imageAdjustment[field] === value,
-  )
   && defaultCardDataByLanguage.some((defaultCardData) => (
     isSameCardData(cardData, defaultCardData)
   ))
@@ -114,7 +105,6 @@ const loadSavedDraft = () => {
     if (
       !savedDraft
       || !isSavedCardData(savedDraft.cardData)
-      || !isSavedImageAdjustment(savedDraft.imageAdjustment)
       || !['standard', 'fullArt'].includes(savedDraft.layoutMode)
     ) {
       return null
@@ -139,16 +129,14 @@ const PokemonCardGenerator = () => {
   const [cardData, setCardData] = useState(() => savedDraft?.cardData ?? initialCardData)
 
   const [imagePreview, setImagePreview] = useState(null)
-  const [imageAdjustment, setImageAdjustment] = useState(
-    () => savedDraft?.imageAdjustment ?? initialImageAdjustment,
-  )
+  const [imageAdjustment, setImageAdjustment] = useState(initialImageAdjustment)
   const [layoutMode, setLayoutMode] = useState(() => savedDraft?.layoutMode ?? 'standard')
   const [imageError, setImageError] = useState('')
   const cardRef = useRef(null)
   const imageUploadIdRef = useRef(0)
 
   useEffect(() => {
-    if (isInitialDraft(cardData, imageAdjustment, layoutMode)) {
+    if (isInitialDraft(cardData, layoutMode)) {
       try {
         localStorage.removeItem(cardDraftStorageKey)
       } catch {
@@ -162,13 +150,12 @@ const PokemonCardGenerator = () => {
     try {
       localStorage.setItem(cardDraftStorageKey, JSON.stringify({
         cardData: cardDataWithoutImage,
-        imageAdjustment,
         layoutMode,
       }))
     } catch {
       // 保存できない環境でもカード編集は継続できるようにする
     }
-  }, [cardData, imageAdjustment, layoutMode])
+  }, [cardData, layoutMode])
 
   // サンプルカードのデータ - 現在の言語に基づいて動的に取得
   const getSampleCards = () => {

--- a/src/components/PokemonCardGenerator.jsx
+++ b/src/components/PokemonCardGenerator.jsx
@@ -3,6 +3,7 @@ import PokemonCard from './PokemonCard'
 import CardForm from './CardForm'
 import DownloadButton from './DownloadButton'
 import { useLanguage } from '../contexts/useLanguage'
+import { translations } from '../contexts/translations'
 import './PokemonCardGenerator.css'
 
 const initialImageAdjustment = {
@@ -36,6 +37,13 @@ const createInitialCardData = (t) => ({
   rarity: 'common',
 })
 
+const defaultCardDataByLanguage = Object.values(translations).map(({ defaultCard }) => ({
+  ...createInitialCardData((key) => {
+    const defaultCardKey = key.split('.')[1]
+    return defaultCard[defaultCardKey]
+  }),
+}))
+
 const isString = (value) => typeof value === 'string'
 const isFiniteNumber = (value) => typeof value === 'number' && Number.isFinite(value)
 
@@ -67,6 +75,39 @@ const isSavedImageAdjustment = (adjustment) => (
   && ['x', 'y', 'zoom', 'width', 'height'].every((field) => isFiniteNumber(adjustment[field]))
 )
 
+const isSameCardData = (cardData, otherCardData) => (
+  cardData.name === otherCardData.name
+  && cardData.hp === otherCardData.hp
+  && cardData.type === otherCardData.type
+  && cardData.description === otherCardData.description
+  && cardData.weakness === otherCardData.weakness
+  && cardData.resistance === otherCardData.resistance
+  && cardData.retreatCost === otherCardData.retreatCost
+  && cardData.cardNumber === otherCardData.cardNumber
+  && cardData.rarity === otherCardData.rarity
+  && cardData.abilities.length === otherCardData.abilities.length
+  && cardData.abilities.every((ability, index) => {
+    const otherAbility = otherCardData.abilities[index]
+    return (
+      ability.name === otherAbility.name
+      && ability.description === otherAbility.description
+      && ability.energyCost === otherAbility.energyCost
+      && ability.damage === otherAbility.damage
+    )
+  })
+)
+
+const isInitialDraft = (cardData, imageAdjustment, layoutMode) => (
+  layoutMode === 'standard'
+  && isSavedImageAdjustment(imageAdjustment)
+  && Object.entries(initialImageAdjustment).every(
+    ([field, value]) => imageAdjustment[field] === value,
+  )
+  && defaultCardDataByLanguage.some((defaultCardData) => (
+    isSameCardData(cardData, defaultCardData)
+  ))
+)
+
 const loadSavedDraft = () => {
   try {
     const savedDraft = JSON.parse(localStorage.getItem(cardDraftStorageKey))
@@ -92,11 +133,7 @@ const loadSavedDraft = () => {
 const PokemonCardGenerator = () => {
   const { t } = useLanguage() // 翻訳機能とユーザーの言語設定を取得
   const initialCardData = createInitialCardData(t)
-  const savedDraftRef = useRef(undefined)
-  if (savedDraftRef.current === undefined) {
-    savedDraftRef.current = loadSavedDraft()
-  }
-  const savedDraft = savedDraftRef.current
+  const [savedDraft] = useState(() => loadSavedDraft())
 
   // カードデータの状態管理 - 保存内容がなければ言語に応じた初期値を使用
   const [cardData, setCardData] = useState(() => savedDraft?.cardData ?? initialCardData)
@@ -109,16 +146,14 @@ const PokemonCardGenerator = () => {
   const [imageError, setImageError] = useState('')
   const cardRef = useRef(null)
   const imageUploadIdRef = useRef(0)
-  const isInitialRenderRef = useRef(true)
-  const skipNextSaveRef = useRef(false)
 
   useEffect(() => {
-    if (isInitialRenderRef.current) {
-      isInitialRenderRef.current = false
-      return
-    }
-    if (skipNextSaveRef.current) {
-      skipNextSaveRef.current = false
+    if (isInitialDraft(cardData, imageAdjustment, layoutMode)) {
+      try {
+        localStorage.removeItem(cardDraftStorageKey)
+      } catch {
+        // 削除できない環境でもカード編集は継続できるようにする
+      }
       return
     }
 
@@ -294,12 +329,6 @@ const PokemonCardGenerator = () => {
   // カードリセット処理 - 言語に応じたデフォルト値に戻す
   const resetCard = () => {
     imageUploadIdRef.current += 1
-    skipNextSaveRef.current = true
-    try {
-      localStorage.removeItem(cardDraftStorageKey)
-    } catch {
-      // 削除できない環境でも画面上のリセットは継続する
-    }
     setCardData(createInitialCardData(t))
     setImagePreview(null)
     setImageAdjustment(initialImageAdjustment)


### PR DESCRIPTION
## 変更内容

- 画像を除くカード入力内容を `localStorage` に自動保存
- ページ表示時に保存済みのカード内容とレイアウトを復元
- 不正な保存データは使用せず、初期状態へフォールバック
- リセット時に保存内容も削除
- 初期カードデータの生成処理を共通化

## 目的

ページの再読み込みや再訪問後も、直前に編集していたカード内容から作業を再開できるようにするためです。アップロード画像は容量が大きいため保存対象に含めません。

## 確認内容

- `npm run lint`
- `npm run build`
- `git diff --check`
- 実ブラウザでカード名と全面アート設定が再読み込み後に復元されること
- 実ブラウザでリセット後に再読み込みしても初期状態になること

Closes #15
