### PR TITLE
ダウンロードボタンの押下回数を計測

### DIFF
--- a/src/components/DownloadButton.jsx
+++ b/src/components/DownloadButton.jsx
@@ -132,7 +132,9 @@ const DownloadButton = ({ cardRef, cardData }) => {
   const { t } = useLanguage()
 
   const generateCardImage = async () => {
-    window.gtag?.('event', 'card_download_click')
+    if (typeof window.gtag === 'function') {
+      window.gtag('event', 'card_download_click')
+    }
 
     const svg = cardRef?.current?.getSvgElement?.()
     if (!svg) {

--- a/src/components/DownloadButton.jsx
+++ b/src/components/DownloadButton.jsx
@@ -132,7 +132,7 @@ const DownloadButton = ({ cardRef, cardData }) => {
   const { t } = useLanguage()
 
   const generateCardImage = async () => {
-    window.gtag?.('event', 'card_download')
+    window.gtag?.('event', 'card_download_click')
 
     const svg = cardRef?.current?.getSvgElement?.()
     if (!svg) {

--- a/src/components/DownloadButton.jsx
+++ b/src/components/DownloadButton.jsx
@@ -132,6 +132,8 @@ const DownloadButton = ({ cardRef, cardData }) => {
   const { t } = useLanguage()
 
   const generateCardImage = async () => {
+    window.gtag?.('event', 'card_download')
+
     const svg = cardRef?.current?.getSvgElement?.()
     if (!svg) {
       setError(t('alerts.cardNotAvailable'))


### PR DESCRIPTION
## 概要

- ダウンロードボタン押下時にGA4イベントを送信
- イベント名は `card_download_click`
- 成功可否ではなく、ボタンが押された回数を計測
- ユーザーが入力したカード情報は送信しない

## 確認内容

- `npm run lint`
- `npm run build`
- 本番ビルドに `card_download_click` が含まれることを確認
- `git diff --check`